### PR TITLE
Better: add instructions to avoid ProGuard warnings on Dimelo Mobile SDK during compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ Update your gradle file in three steps:
     		compile 'com.dimelo.dimelosdk:dimelosdk:1.4.+'
 	}
 
+## /!\ ProGuard warnings
+If you are using ProGuard during your compilation process you might get a lot of warnings caused by the Dimelo Mobile SDK.
+
+In order to fix them you will need to tell ProGuard that the Dimelo dependency is fine and shouldn't trigger any warning, you can do so by adding the following lines to your ProGuard file:
+
+    -dontwarn com.dimelo.**
+    -dontwarn com.squareup.picasso.**
 
 <a name="activate_location_messages"></a>Activate location messages
 -----------------------------

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Update your gradle file in three steps:
     		compile 'com.dimelo.dimelosdk:dimelosdk:1.4.+'
 	}
 
-## /!\ ProGuard warnings
+## :warning: ProGuard warnings
 If you are using ProGuard during your compilation process you might get a lot of warnings caused by the Dimelo Mobile SDK.
 
 In order to fix them you will need to tell ProGuard that the Dimelo dependency is fine and shouldn't trigger any warning, you can do so by adding the following lines to your ProGuard file:


### PR DESCRIPTION
Hi !

This PR's goal is to add instructions in the README on how to avoid ProGuard warnings on the SDK during compilation.

LCL faced this issue and thought that their compilation issue was caused by a conflict between our dependencies and theirs, you can find the related JIRA ticket [here](https://dimelo.atlassian.net/browse/RD-9102).